### PR TITLE
Add Laravel 5 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ and [Oleg Isaev](https://github.com/Malezha).
 | 1.0.*  | 4.0.*   | 2.0.*  |
 | 1.1.*  | 4.1.*   | 2.0.*  |
 | 1.2.*  | 4.2.*   | 2.1.*  |
+| 1.5.*  | 5.0.*   | 3.0.*  |
 
 
 ##Installation

--- a/composer.json
+++ b/composer.json
@@ -30,13 +30,13 @@
 	],
     "require": {
         "php": ">=5.4.0",
-        "illuminate/support": "4.2.*",
-		"cartalyst/sentry": "2.1.*"
+        "illuminate/support": "~5.0",
+        "cartalyst/sentry": "~3.0"
     },
 	"require-dev" : {
-		"phpunit/phpunit": "4.2.*",
-        "orchestra/testbench": "2.2.*",
-		"doctrine/dbal": "2.4.*"
+        "phpunit/phpunit": "~4.5",
+        "orchestra/testbench": "~3.0",
+        "doctrine/dbal": "~2.5"
 	},
     "autoload": {
         "psr-0": {

--- a/composer.json
+++ b/composer.json
@@ -38,6 +38,12 @@
         "orchestra/testbench": "~3.0",
         "doctrine/dbal": "~2.5"
 	},
+	"repositories": [
+		{
+			"type": "vcs",
+			"url": "https://github.com/BootstrapCMS/sentry"
+		}
+	],
     "autoload": {
         "psr-0": {
             "Malezha\\Sentry": "src/"

--- a/src/Malezha/Sentry/Auth/SentryAuthServiceProvider.php
+++ b/src/Malezha/Sentry/Auth/SentryAuthServiceProvider.php
@@ -20,8 +20,6 @@ class SentryAuthServiceProvider extends ServiceProvider {
 	 */
 	public function boot()
 	{
-		$this->package('malezha/sentry-auth-laravel', 'sentry-auth-laravel', __DIR__ . '/../../..');
-
 		$this->app['auth']->extend('sentry', function($app)
 		{
 			$provider = new EloquentUserProvider($app['sentry-hash'], $app['config']->get('auth.model'));

--- a/src/Malezha/Sentry/Auth/SentryUser.php
+++ b/src/Malezha/Sentry/Auth/SentryUser.php
@@ -1,13 +1,13 @@
 <?php namespace Malezha\Sentry\Auth;
 
-use Illuminate\Auth\UserTrait;
-use Illuminate\Auth\UserInterface;
-use Illuminate\Auth\Reminders\RemindableTrait;
-use Illuminate\Auth\Reminders\RemindableInterface;
+use Illuminate\Auth\Authenticatable;
+use Illuminate\Contracts\Auth\Authenticatable as AuthenticatableContract;
+use Illuminate\Auth\Passwords\CanResetPassword;
+use Illuminate\Contracts\Auth\CanResetPassword as CanResetPasswordContract;
 use Cartalyst\Sentry\Users\Eloquent\User;
 
-class SentryUser extends User implements UserInterface, RemindableInterface {
+class SentryUser extends User implements AuthenticatableContract, CanResetPasswordContract {
 
-	use UserTrait, RemindableTrait;
+	use Authenticatable, CanResetPassword;
 
 }

--- a/src/Malezha/Sentry/Hashing/SentryHasher.php
+++ b/src/Malezha/Sentry/Hashing/SentryHasher.php
@@ -1,9 +1,9 @@
 <?php namespace Malezha\Sentry\Hashing;
 
-use Illuminate\Contracts\Hashing\Hasher;
+use Illuminate\Contracts\Hashing\Hasher as HasherContract;
 use Cartalyst\Sentry\Hashing\HasherInterface as SentryHasherInterface;
 
-class SentryHasher implements Hasher {
+class SentryHasher implements HasherContract {
 
 	protected $hasher;
 

--- a/src/Malezha/Sentry/Hashing/SentryHasher.php
+++ b/src/Malezha/Sentry/Hashing/SentryHasher.php
@@ -1,9 +1,9 @@
 <?php namespace Malezha\Sentry\Hashing;
 
-use Illuminate\Hashing\HasherInterface;
+use Illuminate\Contracts\Hashing\Hasher;
 use Cartalyst\Sentry\Hashing\HasherInterface as SentryHasherInterface;
 
-class SentryHasher implements HasherInterface {
+class SentryHasher implements Hasher {
 
 	protected $hasher;
 


### PR DESCRIPTION
All I really did was change version numbers and rename traits and interfaces.
Uses Graham Campbell's Sentry 3.0 fork from https://github.com/BootstrapCMS/sentry
